### PR TITLE
Use helm to install kueue

### DIFF
--- a/kueue.py
+++ b/kueue.py
@@ -95,19 +95,34 @@ class Kueue(pulumi.ComponentResource):
                 provider=opts.provider
             )
         )
-
-        kueue_release = kubernetes.yaml.v2.ConfigFile(
-            "kueue",
-            file=pulumi.Output.format("https://github.com/kubernetes-sigs/kueue/releases/download/{}/manifests.yaml", version),
+        
+        kueue_namespace = kubernetes.core.v1.Namespace(
+            namespace,
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name=namespace
+            ),
             opts=pulumi.ResourceOptions(
                 parent=self,
                 provider=opts.provider
-            ),
+            )
+        )
+        
+        kueue_release = kubernetes.helm.v3.Release(
+            "kueue",
+            name="kueue",
+            chart="oci://registry.k8s.io/kueue/charts/kueue",
+            version=version.apply(lambda v: v.removeprefix("v")),
+            namespace=kueue_namespace.metadata.name,
+            opts=pulumi.ResourceOptions(
+                parent=self,
+                provider=opts.provider
+            )
         )
 
         kueue_controller_deployment = kubernetes.apps.v1.Deployment.get(
             "kueue-controller-deployment",
-            pulumi.Output.format("{}/kueue-controller-manager", namespace),
+            # Pass the id through the release status to ensure this only runs after the release is ready
+            kueue_release.status.apply(lambda _: f"{namespace}/kueue-controller-manager"),
             opts=pulumi.ResourceOptions(
                 parent=self,
                 provider=opts.provider,

--- a/kueue.py
+++ b/kueue.py
@@ -218,6 +218,7 @@ class Kueue(pulumi.ComponentResource):
 
         self.register_outputs({
             "train_namespace": train_namespace,
+            "kueue_namespace": kueue_namespace,
             "kueue_release": kueue_release,
             "kueue_controller": kueue_controller_deployment,
             "resource_flavor": resource_flavor,


### PR DESCRIPTION
The helm chart correctly excludes deployments, statefulsets, etc. from the mutating/validating webhooks. These shouldn't be inspected by the kueue controller, but the regular chart based installation does that due to a lack of templating.
With helm we'll not see intermittent deployment issues in other components.

Verified it in my GKE cluster.